### PR TITLE
removes points of interest from Google base map

### DIFF
--- a/js/maps_lib.js
+++ b/js/maps_lib.js
@@ -44,11 +44,23 @@
 
     	this.currentPinpoint = null;
     	$("#result_count").html("");
+
+        // disable Google's points of interest markers in the basemap
+        var basemapStyles =[
+            {
+                featureType: "poi",
+                elementType: "labels",
+                stylers: [
+                      { visibility: "off" }
+                ]
+            }
+        ];
         
         this.myOptions = {
             zoom: this.defaultZoom,
             center: this.map_centroid,
-            mapTypeId: google.maps.MapTypeId.ROADMAP
+            mapTypeId: google.maps.MapTypeId.ROADMAP,
+            styles: basemapStyles 
         };
         this.geocoder = new google.maps.Geocoder();
         this.map = new google.maps.Map($("#map_canvas")[0], this.myOptions);


### PR DESCRIPTION
Removes points of interest that have recently been made more prominent in the Google base layer.

Before: 😞

<img width="642" alt="screen shot 2018-03-05 at 11 50 56 am" src="https://user-images.githubusercontent.com/919583/36990869-8f9ac1c6-206b-11e8-93d9-8e7179f3a93e.png">

After: 😁

<img width="611" alt="screen shot 2018-03-05 at 11 51 02 am" src="https://user-images.githubusercontent.com/919583/36990889-a1dbdcda-206b-11e8-8a55-2186788806ee.png">
